### PR TITLE
Entry.where() is not working with string keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,77 +1,55 @@
---- 
-dependencies: 
-  bson_ext: 
-    group: 
-    - :default
-    version: ">= 0"
-  rspec: 
-    group: 
-    - :default
-    version: ">= 2.0.0.beta.8"
-  mocha: 
-    group: 
-    - :default
-    version: ">= 0"
-  bundler: 
-    group: 
-    - :default
-    version: ">= 0"
-  jeweler: 
-    group: 
-    - :default
-    version: ">= 0"
-  mongoid: 
-    group: 
-    - :default
-    version: ">= 2.0.0.beta.9"
-specs: 
-- rake: 
-    version: 0.8.7
-- activesupport: 
-    version: 3.0.0.rc2
-- builder: 
-    version: 2.1.2
-- i18n: 
-    version: 0.4.1
-- activemodel: 
-    version: 3.0.0.rc2
-- bson: 
-    version: 1.0.7
-- bson_ext: 
-    version: 1.0.7
-- bundler: 
-    version: 0.9.26
-- diff-lcs: 
-    version: 1.1.2
-- gemcutter: 
-    version: 0.6.1
-- git: 
-    version: 1.2.5
-- json_pure: 
-    version: 1.4.6
-- rubyforge: 
-    version: 2.0.4
-- jeweler: 
-    version: 1.4.0
-- mocha: 
-    version: 0.9.8
-- mongo: 
-    version: 1.0.8
-- tzinfo: 
-    version: 0.3.23
-- will_paginate: 
-    version: 3.0.pre2
-- mongoid: 
-    version: 2.0.0.beta7
-- rspec-core: 
-    version: 2.0.0.beta.20
-- rspec-expectations: 
-    version: 2.0.0.beta.20
-- rspec-mocks: 
-    version: 2.0.0.beta.20
-- rspec: 
-    version: 2.0.0.beta.20
-hash: 6dfab5e2b924a3176f60464404e1350aed0df898
-sources: 
-- Rubygems: 
-    uri: http://gemcutter.org
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activemodel (3.0.1)
+      activesupport (= 3.0.1)
+      builder (~> 2.1.2)
+      i18n (~> 0.4.1)
+    activesupport (3.0.1)
+    bson (1.1.1)
+    bson_ext (1.1.1)
+    builder (2.1.2)
+    diff-lcs (1.1.2)
+    gemcutter (0.6.1)
+    git (1.2.5)
+    i18n (0.4.2)
+    jeweler (1.4.0)
+      gemcutter (>= 0.1.0)
+      git (>= 1.2.5)
+      rubyforge (>= 2.0.0)
+    json_pure (1.4.6)
+    mocha (0.9.9)
+      rake
+    mongo (1.0.9)
+      bson (>= 1.0.5)
+    mongoid (2.0.0.beta.19)
+      activemodel (~> 3.0)
+      mongo (= 1.0.9)
+      tzinfo (~> 0.3.22)
+      will_paginate (~> 3.0.pre)
+    rake (0.8.7)
+    rspec (2.0.1)
+      rspec-core (~> 2.0.1)
+      rspec-expectations (~> 2.0.1)
+      rspec-mocks (~> 2.0.1)
+    rspec-core (2.0.1)
+    rspec-expectations (2.0.1)
+      diff-lcs (>= 1.1.2)
+    rspec-mocks (2.0.1)
+      rspec-core (~> 2.0.1)
+      rspec-expectations (~> 2.0.1)
+    rubyforge (2.0.4)
+      json_pure (>= 1.1.7)
+    tzinfo (0.3.23)
+    will_paginate (3.0.pre2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bson_ext
+  bundler
+  jeweler
+  mocha
+  mongoid (>= 2.0.0.beta.9)
+  rspec (>= 2.0.0.beta.8)

--- a/lib/mongoid/i18n.rb
+++ b/lib/mongoid/i18n.rb
@@ -7,7 +7,9 @@ module Mongoid
 
     module ClassMethods
       def localized_field(name, options = {})
-        field name, options.merge(:type => LocalizedField)
+        options[:i18n_type] = options[:type] || "String"
+        options[:type] = LocalizedField
+        field name, options
       end
 
       def criteria
@@ -36,3 +38,4 @@ module Mongoid
     end
   end
 end
+

--- a/lib/mongoid/i18n/localized_criteria.rb
+++ b/lib/mongoid/i18n/localized_criteria.rb
@@ -10,7 +10,7 @@ module Mongoid
       protected
       
       def expand_localized_fields_in_selector
-        @klass.fields.select { |k,f| @selector.keys.include?(k.to_sym) && f.type == LocalizedField }.each do |k,v|
+        @klass.fields.select { |k,f| @selector.symbolize_keys!.keys.include?(k.to_sym) && f.type == LocalizedField }.each do |k,v|
           @selector["#{k}.#{::I18n.locale}"] = @selector.delete(k.to_sym)
         end
       end

--- a/lib/mongoid/i18n/localized_field.rb
+++ b/lib/mongoid/i18n/localized_field.rb
@@ -1,6 +1,8 @@
 module Mongoid
   module I18n
     class LocalizedField < Hash
+      attr_accessor :i18n_type
     end
   end
 end
+

--- a/spec/integration/mongoid/i18n_spec.rb
+++ b/spec/integration/mongoid/i18n_spec.rb
@@ -38,6 +38,10 @@ describe Mongoid::I18n, "localized_field" do
         it "should use the current locale value" do
           Entry.where(:title => 'Title').first.should == @entry
         end
+
+        it "should work with string keys" do
+          Entry.where('title' => 'Title').first.should == @entry
+        end
       end
 
       describe "find(:first) with :conditions" do


### PR DESCRIPTION
Hi Papipo,

I've added symbolize_keys! to 'expand_localized_fields_in_selector' (LocalizedCriteria class) and simple spec to integration test.

Entry.where('title' => "Title") didn't work for me (failing test - it worked only with :title as a symbol).
Please see specs

Best
Jozef
