### PR TITLE
Use an internal locale variable on lookups, not I18n.locale

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,6 +52,8 @@ Criteria is handled for you:
   Entry.where(:title => 'Title') # This will search automatically for the 'en' translation
   Entry.find(:first, :title.in => ['Stuff', 'More stuff']) # find() and complex criteria also works
 
+== Setting the locale from the controller
+
 If using the default I18n.locale is not flexible enough for you, you may set a custom locale in any controller that inherits from ApplicationController, or ApplicationController itself. This will set the internal Mongoid::I18n.locale to be different than the actual I18n.locale.
 
   class ApplicationController < ActionController::Base

--- a/README.rdoc
+++ b/README.rdoc
@@ -57,19 +57,22 @@ Criteria is handled for you:
 If using the default I18n.locale is not flexible enough for you, you may set a custom locale in any controller that inherits from ApplicationController, or ApplicationController itself. This will set the internal Mongoid::I18n.locale to be different than the actual I18n.locale.
 
   class ApplicationController < ActionController::Base
-    # You must use mongoid_i18n_locale, as this is called in a before_filter
+    # You must use mongoid_i18n_locale, as this is called by a internal before_filter set by Mongoid::I18n
     def mongoid_i18n_locale
       current_user.locale || params[:locale]
     end
   end
 
-If you'd like to set both values explicitly, you may continue just setting the I18n.locale like most Rails guides already suggest:
+If you'd like to set both values explicitly, you may continue just setting the I18n.locale like most Rails guides already suggest and Mongoid::I18n will use that same locale.
 
   class ApplicationController < ActionController::Base
     before_filter :set_user_locale
     
     def set_user_locale
       I18n.locale = params[:locale]
+      
+      Rails.logger.info I18n.locale # => :es
+      Rails.logger.info Mongoid::I18n.locale # => :es
     end
   end
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,10 +20,10 @@ Now you can add the module to the documents that need localization:
   
 This will allow you to do stuff like this:
 
-  I18n.locale = :en
+  I18n.locale = :en # or Mongoid::I18n.locale = :en
   @entry = Entry.new(:title => 'Title') # will be stored in the 'en' translation
   
-  I18n.locale :es
+  I18n.locale = :es # or Mongoid::I18n.locale = :es
   @entry.title = 'Título' # will be stored in the 'es' translation
   
   @entry.title_translations # this returns a hash: {'en' => 'Title', 'es' => 'Title'}
@@ -51,7 +51,34 @@ Criteria is handled for you:
   I18n.locale = :en
   Entry.where(:title => 'Title') # This will search automatically for the 'en' translation
   Entry.find(:first, :title.in => ['Stuff', 'More stuff']) # find() and complex criteria also works
+
+If using the default I18n.locale is not flexible enough for you, you may set a custom locale in any controller that inherits from ApplicationController, or ApplicationController itself. This will set the internal Mongoid::I18n.locale to be different than the actual I18n.locale.
+
+  class ApplicationController < ActionController::Base
+    # You must use mongoid_i18n_locale, as this is called in a before_filter
+    def mongoid_i18n_locale
+      current_user.locale || params[:locale]
+    end
+  end
+
+If you'd like to set both values explicitly, you may continue just setting the I18n.locale like most Rails guides already suggest:
+
+  class ApplicationController < ActionController::Base
+    before_filter :set_user_locale
+    
+    def set_user_locale
+      I18n.locale = params[:locale]
+    end
+  end
+
+On startup, Mongoid::I18n uses the default I18n.locale from your project as a starter. But if you set a new locale anywhere within your application, Mongoid::I18n will use the same locale. So imagine, our default locale is "en":
+
+  I18n.locale == :en # => true
+  Mongoid::I18n.locale == :en # => true
   
+  # Now with setting a new locale, Mongoid::I18n will return the same
+  I18n.locale = :es # => true
+  Mongoid::I18n.locale == :es # => true
 
 == Note on Patches/Pull Requests
  

--- a/lib/mongoid/i18n/controller.rb
+++ b/lib/mongoid/i18n/controller.rb
@@ -1,0 +1,21 @@
+module Mongoid
+  module I18n
+    class Controller
+      def self.included(base)
+        base.before_filter :set_mongoid_i18n_locale
+      end
+      
+      protected
+      
+      # End user must override in their own controllers
+      def mongoid_i18n_locale; end
+      
+      # Called before requests so subsequent database lookups use the correct locale
+      def set_mongoid_i18n_locale
+        return if mongoid_i18n_locale.nil?
+        
+        ::Mongoid::I18n.locale = mongoid_i18n_locale
+      end
+    end
+  end
+end

--- a/lib/mongoid/i18n/criterion/selector.rb
+++ b/lib/mongoid/i18n/criterion/selector.rb
@@ -2,7 +2,7 @@ module Mongoid
   module Criterion
     class Selector< Hash
       def []=(key, value)
-        key = "#{key}.#{::I18n.locale}" if fields[key.to_s].try(:type) == Mongoid::I18n::LocalizedField
+        key = "#{key}.#{::Mongoid::I18n.locale}" if fields[key.to_s].try(:type) == Mongoid::I18n::LocalizedField
         super
       end
     end

--- a/lib/mongoid/i18n/extension.rb
+++ b/lib/mongoid/i18n/extension.rb
@@ -1,0 +1,13 @@
+module I18n
+  class << self
+    def locale=(name)
+      Mongoid::I18n.locale = name
+      config.locale = name
+    end
+    
+    def default_locale=(name)
+      Mongoid::I18n.default_locale = name
+      config.default_locale = name
+    end
+  end
+end

--- a/lib/mongoid/i18n/localized_validator.rb
+++ b/lib/mongoid/i18n/localized_validator.rb
@@ -3,9 +3,9 @@ module Mongoid
     class LocalizedValidator < ActiveModel::EachValidator
       def validate_each record, attribute, value
         if options[:mode] == :only_default
-          if record.send("#{attribute}_translations")[::I18n.default_locale.to_s].blank?
+          if record.send("#{attribute}_translations")[Mongoid::I18n.default_locale].blank?
             record.errors.add(attribute, :locale_blank, options.except(:mode).merge(
-              :cur_locale => ::I18n.t(:"locales.#{::I18n.default_locale}", :default => ::I18n.default_locale.to_s)
+              :cur_locale => ::I18n.t(:"locales.#{Mongoid::I18n.default_locale}", :default => Mongoid::I18n.default_locale)
             ))
           end
         elsif options[:mode] == :one_locale
@@ -18,7 +18,7 @@ module Mongoid
           diffloc.each do |locale| 
             record.errors.add(attribute, :locale_blank, options.except(:mode).merge(
               :cur_locale => ::I18n.t(:"locales.#{locale}", :default => locale.to_s)
-            )) 
+            ))
           end
         end
       end	

--- a/spec/integration/mongoid/i18n_spec.rb
+++ b/spec/integration/mongoid/i18n_spec.rb
@@ -25,7 +25,7 @@ end
 
 describe Mongoid::I18n, "localized_field" do
   before do
-    I18n.locale = :en
+    Mongoid::I18n.locale = :en
   end
 
   describe "without an assigned value" do
@@ -73,7 +73,7 @@ describe Mongoid::I18n, "localized_field" do
 
     describe "when the locale is changed" do
       before do
-        I18n.locale = :es
+        Mongoid::I18n.locale = :es
       end
 
       it "should return a blank value" do
@@ -97,7 +97,7 @@ describe Mongoid::I18n, "localized_field" do
 
           it "the localized field value should be correct" do
             @entry.title.should == 'Título'
-            I18n.locale = :en
+            Mongoid::I18n.locale = :en
             @entry.title.should == 'Title'
             @entry.title_translations.should == {'en' => 'Title', 'es' => 'Título'}
           end
@@ -125,7 +125,7 @@ describe Mongoid::I18n, "localized_field" do
 
         describe "if we go back to the original locale" do
           before do
-            I18n.locale = :en
+            Mongoid::I18n.locale = :en
           end
 
           it "should return the original value" do
@@ -181,8 +181,8 @@ end
 
 describe Mongoid::I18n, "localized_field with :use_default_if_empty => true" do
   before do
-    I18n.default_locale = :en
-    I18n.locale = :en
+    Mongoid::I18n.default_locale = :en
+    Mongoid::I18n.locale = :en
   end
 
   describe "without an assigned value" do
@@ -206,7 +206,7 @@ describe Mongoid::I18n, "localized_field with :use_default_if_empty => true" do
 
     describe "when the locale is changed" do
       before do
-        I18n.locale = :it
+        Mongoid::I18n.locale = :it
       end
 
       it "should return the value of the default locale" do
@@ -224,7 +224,7 @@ describe Mongoid::I18n, "localized_field with :use_default_if_empty => true" do
 
         describe "if we go back to the original locale" do
           before do
-            I18n.locale = :en
+            Mongoid::I18n.locale = :en
           end
 
           it "should return the original value" do
@@ -239,7 +239,7 @@ end
 describe Mongoid::I18n, "localized_field with :clear_empty_values => true" do
   describe "when are assigned two translations" do
     before do
-      I18n.locale = :en
+      Mongoid::I18n.locale = :en
       @entry = Entry.new
       @entry.title_without_empty_values_translations = {"en" => "Title en", "it" => "Title it"}
     end
@@ -272,8 +272,8 @@ end
 
 describe Mongoid::I18n, "localized_field with validation 'validates_default_locale'" do
   before do
-    I18n.default_locale = :en
-    I18n.locale = :it
+    Mongoid::I18n.default_locale = :en
+    Mongoid::I18n.locale = :it
     @entry = EntryWithValidations.new
   end
 
@@ -303,8 +303,8 @@ end
 
 describe Mongoid::I18n, "localized_field with validation 'validates_one_locale'" do
   before do
-    I18n.default_locale = :en
-    I18n.locale = :it
+    Mongoid::I18n.default_locale = :en
+    Mongoid::I18n.locale = :it
     @entry = EntryWithValidations.new
   end
 
@@ -333,9 +333,9 @@ end
 
 describe Mongoid::I18n, "localized_field with validation 'validates_all_locales'" do
   before do
-    I18n.default_locale = :en
+    Mongoid::I18n.default_locale = :en
     I18n.available_locales = [:en, :it, :de, :fr]
-    I18n.locale = :it
+    Mongoid::I18n.locale = :it
     @entry = EntryWithValidations.new
   end
 
@@ -361,6 +361,28 @@ describe Mongoid::I18n, "localized_field with validation 'validates_all_locales'
 
     it "no error for that field is added to entry errors list" do
       @entry.errors.include?(:title_validated_with_all_locales).should be_false
+    end
+  end
+end
+
+describe ::I18n, "extension" do
+  before do
+    ::I18n.locale = :en
+  end
+  
+  describe "with default value" do
+    it "should return same as translation locale" do
+      Mongoid::I18n.locale.should == ::I18n.locale.to_s
+    end
+  end
+  
+  describe "with custom locale set on default i18n" do
+    before do
+      ::I18n.locale = :it
+    end
+    
+    it "should return same as translation locale" do
+      Mongoid::I18n.locale.should == ::I18n.locale.to_s
     end
   end
 end


### PR DESCRIPTION
First off, thank you for writing this. I have been thinking about how i'd make one the last few days and it's awesome to see you already had one the minute I actually started looking to see if someone already made it.

I found it not extremely ideal to rely on whatever I18n.locale may read out to be, as it didn't fit the use case for the application I am using it in.

I needed the ability for Mongoid::I18n lookups to use a specific locale, while I18n.locale remained as :en.

Setting locale from I18n

```
I18n.locale # => :en
Mongoid::I18n.locale # => :en
```

Setting global locale from I18n (nothing different than first example)

```
I18n.locale = :es # => :es
Mongoid::I18n.locale # => :es
```

But, setting it directly on Mongoid::I18n will not change or read from I18n.locale when the translations are looked up by Mongoid.

```
Mongoid::I18n.locale = :de # => :de
I18n.locale # => :es
```

That way any subsequent model queries will read from the de locale, not es.

Let me know what you think! Tests are included.
