### PR TITLE
Patch fixes compatibility with mongoid 2.3.x.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,32 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.10)
-      activesupport (= 3.0.10)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activesupport (3.0.10)
-    bson (1.3.1)
-    bson_ext (1.3.1)
-    builder (2.1.2)
-    diff-lcs (1.1.2)
+    activemodel (3.1.1)
+      activesupport (= 3.1.1)
+      builder (~> 3.0.0)
+      i18n (~> 0.6)
+    activesupport (3.1.1)
+      multi_json (~> 1.0)
+    bson (1.4.0)
+    bson_ext (1.4.0)
+    builder (3.0.0)
+    diff-lcs (1.1.3)
     git (1.2.5)
-    i18n (0.5.0)
+    i18n (0.6.0)
     jeweler (1.6.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
-    mocha (0.9.12)
-    mongo (1.3.1)
-      bson (>= 1.3.1)
-    mongoid (2.1.8)
+    metaclass (0.0.1)
+    mocha (0.10.0)
+      metaclass (~> 0.0.1)
+    mongo (1.4.0)
+      bson (= 1.4.0)
+    mongoid (2.2.2)
       activemodel (~> 3.0)
       mongo (~> 1.3)
       tzinfo (~> 0.3.22)
+    multi_json (1.0.3)
     rake (0.9.2)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
@@ -32,7 +36,7 @@ GEM
     rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
-    tzinfo (0.3.29)
+    tzinfo (0.3.30)
 
 PLATFORMS
   ruby
@@ -42,5 +46,5 @@ DEPENDENCIES
   bundler
   jeweler
   mocha
-  mongoid (>= 2.1.0)
+  mongoid (~> 2.2.0)
   rspec

--- a/lib/mongoid/i18n/localized_field.rb
+++ b/lib/mongoid/i18n/localized_field.rb
@@ -31,7 +31,7 @@ module Mongoid
 
       # Assing new translation to translation table.
       def assign(object, value)
-        object.merge(locale => value)
+        (object || {}).merge(locale => value)
       end
 
       # Replace translation hash with new one. If :clear_empty_values is set to


### PR DESCRIPTION
It's strange, but it seems like default value not always set. Little patch applied.

Tested with 2.2.2 and 2.3.0 and all test green. 
