### PR TITLE
Fix bson dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source :gemcutter
 
 gem "mongoid", '>= 2.1.0'
-gem "bson_ext"
 
 group :development, :test do
+  gem "bson_ext"
   gem "rspec"
   gem "mocha"
   gem "jeweler"


### PR DESCRIPTION
Do not depend on bson_ext or bson, since its required by mongoid itself, and user may want to use pure ruby bson gem, or whatever implements bson.
